### PR TITLE
Fixes

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ A Simple & Easy Logging package for Go(golang). EasyLog is highly stable and thr
 ## Installation
 
 ``` bash
-$ go get github.com/zajann/easylog
+$ go get github.com/Astera-org/easylog
 ```
 
 ## Usage
@@ -14,7 +14,7 @@ $ go get github.com/zajann/easylog
 package main
 
 import (
-	log "github.com/zajann/easylog"
+	log "github.com/Astera-org/easylog"
 )
 
 func main() {
@@ -27,7 +27,7 @@ func main() {
     ); if err != nil {
         panic(err)
     }
- 	
+
     log.Info("Hello, easylog !")
 }
 ```

--- a/easylog_test.go
+++ b/easylog_test.go
@@ -1,0 +1,16 @@
+package easylog
+
+import (
+	"os"
+	"testing"
+)
+
+func TestBasic(t *testing.T) {
+	if err := os.Chdir(t.TempDir()); err != nil {
+		t.Fatal(err)
+	}
+	if err := Init(); err != nil {
+		t.Fatal(err)
+	}
+	Debug("Hello, World!")
+}

--- a/fmt.go
+++ b/fmt.go
@@ -5,20 +5,9 @@ import (
 )
 
 const (
-	logFmt = "TIME, LEVEL, PID, MSG"
-	//timeFmt = "20060102150405"
 	timeFmt = "01-02 15:04:05"
 )
 
 func format(lv LogLevel, msg string) string {
-	//fmt := logFmt
-
-	//fmt = strings.Replace(fmt, "TIME", time.Now().Format(timeFmt), 1)
-	//fmt = strings.Replace(fmt, "LEVEL", levelFmt[lv], 1)
-	//fmt = strings.Replace(fmt, "PID", strconv.Itoa(os.Getpid()), 1)
-	//fmt = strings.Replace(fmt, "MSG", msg, 1)
-
-	fmt := "" + time.Now().Format(timeFmt) + ", " + levelFmt[lv] + ": " + msg
-
-	return fmt
+	return "" + time.Now().Format(timeFmt) + ", " + levelFmt[lv] + ": " + msg
 }


### PR DESCRIPTION
* Handle os.Args[0] being an absolute path. Previously this crashed whenever the binary was run by `go test` due to this issue.
* Update paths in README.
* Use filepath.Join which properly handles absolute paths.
* Don't panic in Init(), just return the error.
* Add a function access the Logger.
* Add a test.